### PR TITLE
#11 Menu added, theme toggle implemented for future use also.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
-
 {
   "$schema": "https://json.schemastore.org/prettierrc",
   "semi": false,
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "trailingComma": "none"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,10 @@
 <script setup>
-  import Header from './components/Header.vue'
+import Header from './components/Header.vue'
 </script>
 
 <template>
   <Header />
-  <nav>
-    <router-link to="/sysslor">Sysslor</router-link>
-    <router-link to="/beloningar">Belöningar</router-link>
-  </nav>
   <router-view />
 </template>
 
-<style scoped>
-  nav {
-    display: flex;
-    gap: 1rem;
-  }
-</style>
+<style scoped></style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -19,9 +19,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <header>
+  <header class="d-flex justify-space-between align-center">
     <img id="logo" src="../assets/logo.svg" alt="Logo Syssla Smart" />
-    <div id="user">
+    <div id="user" class="d-flex">
       <img id="avatar" src="../assets/avatarIcon.svg" alt="User icon" @click.stop="toggleMenu" />
       <v-overlay
         v-model="menuOpen"
@@ -30,30 +30,30 @@ onBeforeUnmount(() => {
         style="z-index: 1"
       ></v-overlay>
       <nav id="menu" :class="{ open: menuOpen }">
-        <div id="menu-header">
+        <div id="menu-header" class="d-flex justify-space-between align-center">
           <img id="avatar-menu" src="../assets/avatarIcon.svg" alt="User icon" />
           <v-icon class="black-text" size="40" color="black" @click="menuOpen = false"
             >mdi-close</v-icon
           >
         </div>
-        <div id="user-score">
+        <div id="user-score" class="d-flex align-center">
           <v-icon class="yellow-text star-icon" size="30" color="yellow">mdi-star</v-icon>
           <span>12 poäng</span>
         </div>
-        <div id="menu-content">
-          <div id="menu-category" class="py-5">
+        <div id="menu-content" class="d-flex-column">
+          <div id="menu-category" class="py-5 d-flex align-center">
             <v-icon class="black-text" size="30" color="black">mdi-trophy-variant</v-icon>
             <span>Belöningar</span>
           </div>
-          <div id="menu-category" class="py-5">
+          <div id="menu-category" class="py-5 d-flex align-center">
             <v-icon class="black-text" size="30" color="black">mdi-history</v-icon>
             <span>Historik</span>
           </div>
-          <div id="menu-category" class="py-5">
+          <div id="menu-category" class="py-5 d-flex align-center">
             <v-icon class="black-text" size="30" color="black">mdi-cog</v-icon>
             <span>Inställningar</span>
           </div>
-          <div id="menu-category" class="py-5">
+          <div id="menu-category" class="py-5 d-flex align-center">
             <v-icon class="black-text" size="30" color="black">mdi-sync</v-icon>
             <span>Synka hushåll</span>
           </div>
@@ -61,14 +61,14 @@ onBeforeUnmount(() => {
             <v-switch label="Tema" inset @click.stop></v-switch>
           </div>
         </div>
-        <div id="menu-footer">
+        <div id="menu-footer" class="d-flex justify-end align-center">
           <span>Logga ut</span>
           <v-icon class="black-text" size="30" color="black">mdi-logout</v-icon>
         </div>
       </nav>
     </div>
   </header>
-  <div id="view-nav" class="py-2">
+  <div id="view-nav" class="py-2 d-flex ga-4">
     <router-link to="/sysslor">Sysslor</router-link>
     <router-link to="/beloningar">Belöningar</router-link>
   </div>
@@ -81,18 +81,12 @@ header {
   padding: 0.625rem 1.25rem;
   width: 100%;
   z-index: 10;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   border-radius: 0 0 8px 8px;
   box-shadow:
     rgba(9, 30, 66, 0.25) 0px 4px 8px -2px,
     rgba(9, 30, 66, 0.08) 0px 0px 0px 1px;
   position: sticky;
   top: 0;
-}
-#user {
-  display: flex;
 }
 #avatar {
   height: 3rem;
@@ -113,17 +107,12 @@ header {
   transform: translateX(0);
 }
 #menu-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: 0.625rem;
 }
 #avatar-menu {
   height: 3rem;
 }
 #user-score {
-  display: flex;
-  align-items: center;
   padding: 1.25rem;
 }
 #user-score span {
@@ -132,13 +121,9 @@ header {
   padding-left: 0.5rem;
 }
 #menu-content {
-  display: flex;
-  flex-direction: column;
   padding: 1.25rem;
 }
 #menu-category {
-  display: flex;
-  align-items: center;
   border-left-width: 0px;
   border-top-width: 0px;
   border-bottom-width: 1px;
@@ -157,9 +142,6 @@ header {
 }
 #menu-footer {
   padding: 0.625rem;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
   position: absolute;
   bottom: 1rem;
   right: 1rem;
@@ -168,10 +150,6 @@ header {
   font-size: 1.25rem;
   color: black;
   padding-right: 0.5rem;
-}
-#view-nav {
-  display: flex;
-  gap: 1rem;
 }
 
 /* Blinka lilla stjäna där */

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,34 +1,205 @@
 <script setup>
-  import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+const menuOpen = ref(false)
+const toggleMenu = () => {
+  menuOpen.value = !menuOpen.value
+}
+const closeMenu = (event) => {
+  if (!event.target.closest('#meny') && !event.target.closest('#avatar')) {
+    menuOpen.value = false
+  }
+}
+onMounted(() => {
+  document.addEventListener('click', closeMenu)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('click', closeMenu)
+})
 </script>
 
 <template>
   <header>
     <img id="logo" src="../assets/logo.svg" alt="Logo Syssla Smart" />
-    <img id="avatar" src="../assets/avatarIcon.svg" alt="User icon" />
+    <div id="user">
+      <img id="avatar" src="../assets/avatarIcon.svg" alt="User icon" @click.stop="toggleMenu" />
+      <v-overlay
+        v-model="menuOpen"
+        class="overlay"
+        @click="menuOpen = false"
+        style="z-index: 1"
+      ></v-overlay>
+      <nav id="menu" :class="{ open: menuOpen }">
+        <div id="menu-header">
+          <img id="avatar-menu" src="../assets/avatarIcon.svg" alt="User icon" />
+          <v-icon class="black-text" size="40" color="black" @click="menuOpen = false"
+            >mdi-close</v-icon
+          >
+        </div>
+        <div id="user-score">
+          <v-icon class="yellow-text star-icon" size="30" color="yellow">mdi-star</v-icon>
+          <span>12 poäng</span>
+        </div>
+        <div id="menu-content">
+          <div id="menu-category" class="py-5">
+            <v-icon class="black-text" size="30" color="black">mdi-trophy-variant</v-icon>
+            <span>Belöningar</span>
+          </div>
+          <div id="menu-category" class="py-5">
+            <v-icon class="black-text" size="30" color="black">mdi-history</v-icon>
+            <span>Historik</span>
+          </div>
+          <div id="menu-category" class="py-5">
+            <v-icon class="black-text" size="30" color="black">mdi-cog</v-icon>
+            <span>Inställningar</span>
+          </div>
+          <div id="menu-category" class="py-5">
+            <v-icon class="black-text" size="30" color="black">mdi-sync</v-icon>
+            <span>Synka hushåll</span>
+          </div>
+          <div id="theme-toggle" class="py-5">
+            <v-switch label="Tema" inset @click.stop></v-switch>
+          </div>
+        </div>
+        <div id="menu-footer">
+          <span>Logga ut</span>
+          <v-icon class="black-text" size="30" color="black">mdi-logout</v-icon>
+        </div>
+      </nav>
+    </div>
   </header>
+  <div id="view-nav" class="py-2">
+    <router-link to="/sysslor">Sysslor</router-link>
+    <router-link to="/beloningar">Belöningar</router-link>
+  </div>
 </template>
 
 <style scoped>
-  h1 {
-    font-size: 1rem;
-  }
+header {
+  background-color: #f1f6ff;
+  color: white;
+  padding: 0.625rem 1.25rem;
+  width: 100%;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 0 0 8px 8px;
+  box-shadow:
+    rgba(9, 30, 66, 0.25) 0px 4px 8px -2px,
+    rgba(9, 30, 66, 0.08) 0px 0px 0px 1px;
+  position: sticky;
+  top: 0;
+}
+#user {
+  display: flex;
+}
+#avatar {
+  height: 3rem;
+  cursor: pointer;
+}
+#menu {
+  background-color: #fff;
+  width: 20rem;
+  height: 100vh;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transform: translateX(50rem);
+  transition: transform 0.5s ease-in-out;
+  z-index: 10;
+}
+#menu.open {
+  transform: translateX(0);
+}
+#menu-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.625rem;
+}
+#avatar-menu {
+  height: 3rem;
+}
+#user-score {
+  display: flex;
+  align-items: center;
+  padding: 1.25rem;
+}
+#user-score span {
+  font-size: 1.25rem;
+  color: black;
+  padding-left: 0.5rem;
+}
+#menu-content {
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem;
+}
+#menu-category {
+  display: flex;
+  align-items: center;
+  border-left-width: 0px;
+  border-top-width: 0px;
+  border-bottom-width: 1px;
+  border-right-width: 0px;
+  border-style: solid;
+  border-bottom-color: rgba(34, 37, 41, 0.25);
+}
+#menu-category span {
+  font-size: 1.25rem;
+  color: black;
+  padding-left: 0.5rem;
+}
+::v-deep(.v-label) {
+  font-size: 1.25rem !important;
+  color: black !important;
+}
+#menu-footer {
+  padding: 0.625rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+}
+#menu-footer span {
+  font-size: 1.25rem;
+  color: black;
+  padding-right: 0.5rem;
+}
+#view-nav {
+  display: flex;
+  gap: 1rem;
+}
 
-  header {
-    background-color: #f1f6ff;
-    color: white;
-    padding: 10px 20px;
-    width: 100%;
-    z-index: 10;
-    display: flex;
-    justify-content: space-between;
-    /* gör så logo är till vänster och avataren till höger, med utrymme emellan*/
-    align-items: center;
-    border-radius: 0 0 8px 8px;
-    box-shadow: rgba(9, 30, 66, 0.25) 0px 4px 8px -2px,
-      rgba(9, 30, 66, 0.08) 0px 0px 0px 1px;
-    /* skugga under header */
-    position: sticky;
-    top: 0;
+/* Blinka lilla stjäna där */
+.star-icon {
+  animation: sparkle 1.5s infinite ease-in-out;
+}
+
+@keyframes sparkle {
+  0% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
   }
+  25% {
+    opacity: 0.8;
+    transform: scale(1.2) rotate(20deg);
+    filter: brightness(1.5);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(0.9) rotate(-20deg);
+  }
+  75% {
+    opacity: 0.8;
+    transform: scale(1.1) rotate(10deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}
 </style>


### PR DESCRIPTION
Meny finns nu, dock är mycket placeholder, så som <span>-taggar istället för faktiska länkar osv. Theme toggle finns implementerad för dark/light mode framöver, men kan tänka mig det kommer bli en ganska stor ticket med det från att ha kollat Vuetifys docs.

Går att stänga menyn både med att klicka utanför den eller på X:et som förväntat.

Jag flyttade även in nav:et som låg i App.vue till header-komponenten och gav det lite extra padding på Y axeln så det inte blir så cramped. 

Lade även till trailingComma i prettierrc.json i denna commit (orkar inte göra en separat för det).